### PR TITLE
2.1.0.2. fix cachemanager

### DIFF
--- a/upload/admin/controller/module/cachemanager.php
+++ b/upload/admin/controller/module/cachemanager.php
@@ -133,7 +133,7 @@ class ControllerModuleCachemanager extends Controller {
 		if(file_exists($dirname)) {
 			if(is_dir($dirname)){
 				$dir=opendir($dirname);
-				while($filename=readdir($dir)){
+				while(($filename=readdir($dir)) !== false){
 					if($filename!="." && $filename!=".."){
 						$file=$dirname."/".$filename;
 						$this->deldir($file); 


### PR DESCRIPTION
в некоторых случаях метод deldir не перебирал все вложенные папки, например, если натыкался на папку с названием 0