### PR TITLE
ocshop-2.1.0.2. fix seo_pro ssl_routes check

### DIFF
--- a/upload/catalog/controller/common/seo_pro.php
+++ b/upload/catalog/controller/common/seo_pro.php
@@ -176,7 +176,7 @@ class ControllerCommonSeoPro extends Controller {
 			$url_info['scheme'] = 'http';
 			} else {
 			foreach ($this->ssl_routes as $ssl_route) {
-				if (stristr($route, $ssl_route)) {
+				if (stripos($route, $ssl_route) === 0) {
 			$url_info['scheme'] = 'https';
 				}
 			}


### PR DESCRIPTION
правильней проверять не вхождение строки, а "начинается с"