### PR TITLE
Update filemanager.php

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -41,7 +41,7 @@ class ControllerCommonFileManager extends Controller {
 
 		$this->load->model('tool/image');
 
-		//if (substr(str_replace('\\', '/', realpath($directory . '/' . $filter_name)), 0, strlen(DIR_IMAGE . 'catalog')) == DIR_IMAGE . 'catalog') {
+		if (substr(str_replace('\\', '/', realpath($directory) . '/' . $filter_name), 0, strlen(DIR_IMAGE . 'catalog')) == str_replace('\\', '/', DIR_IMAGE . 'catalog')) {
 			// Get directories
 			$directories = glob($directory . '/' . $filter_name . '*', GLOB_ONLYDIR);
 
@@ -55,7 +55,7 @@ class ControllerCommonFileManager extends Controller {
 			if (!$files) {
 				$files = array();
 			}
-		//}
+		}
 
 		// Merge directories and files
 		$images = array_merge($directories, $files);


### PR DESCRIPTION
Устанавливаем из OpenCart 3 Без этого кода злоумышленик мог бы просматривать название каталогов не имея ФТП доступа.
В общем видим, что изображения не искало из-за не экранированных слэшей.